### PR TITLE
Creation of 'contact' links - Version to integrate

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -38,7 +38,7 @@ p, a {
     width: 150px;
     height: 150px;
 }
-img {
+.identity__photo img {
     height: 100%;
     width: 100%;
     object-fit: cover;
@@ -59,6 +59,12 @@ img {
     justify-content: space-between;
     align-items: center;
     padding: 1.5em 3em 1.5em 3em;
+}
+
+/* gestion du style des liens dynamiques de 'contact' */
+.contact a {
+    text-decoration: none;
+    color: white;
 }
 
 /* disposition du bandeau 'CV-description' en ligne */

--- a/index.html
+++ b/index.html
@@ -24,14 +24,22 @@
         <!-- Contact du CV -->
         <div class="contact">
             <address class="contact__address">
-                <p>12 rue des Oliviers</p>
-                <p>53200 La Roche-Neuville</p>
+                <!-- lien vers l'adresse dans Google Maps - Ouverture d'une nouvelle page -->
+                <a href="https://www.google.com/maps/place/12+Rue+des+Oliviers,+53200+La+Roche-Neuville/
+                            @47.8746148,-0.7546056,17z/data=!3m1!4b1!4m6!3m5!1s0x4808f12c7939a8a7:0xaefceff0de598651!8m2!3d47.8746112!
+                            4d-0.7520307!16s%2Fg%2F11c1fvm555?entry=ttu"
+                    target="_blank">
+                    <p>12 rue des Oliviers</p>
+                    <p>53200 La Roche-Neuville</p>
+                </a>
             </address>
             <div class="contact__email">
-                <p>jane.doe@gmail.com</p>
+                <!-- lien avec l'éditeur de messagerie -->
+                <a href="mailto:jane.doe@gmail.com">jane.doe@gmail.com</a>
             </div>
             <div class="contact__phone">
-                <p>0606060606</p>
+                <!-- lien avec le numéro de téléphone -->
+                <a href="tel: 0606060606">0606060606</a>           
             </div>
         </div>    
     </header>


### PR DESCRIPTION
Creation of 'contact' links

The address must refer to the **Google maps** page, the email address to the **send email** and the telephone to the **phone call**.

- [x] visualization of the postal address (in a new Google maps page...)
- [x] opening an email (message to complete...)
- [x] phone call (in a configured phone application window...)
